### PR TITLE
Add try-catch to handlePasswordChange in actions.ts

### DIFF
--- a/app/(auth)/hooks/useReset.ts
+++ b/app/(auth)/hooks/useReset.ts
@@ -15,13 +15,12 @@ export function useReset() {
       formData.append("token", token);
     }
     setResetState({ status: 'in_progress' });
-    try {
-      await handlePasswordChange(formData);
-      setResetState({ status: 'success' });
+    const { status } = await handlePasswordChange(formData);
+      setResetState({ status });
+    if (status === 'success') {
       toast.success('Password reset successfully');
       router.refresh();
-    } catch (error) {
-      setResetState({ status: 'failed' });
+    } else {
       toast.error('Failed to reset password');
     }
   };

--- a/app/(auth)/hooks/useUpdate.ts
+++ b/app/(auth)/hooks/useUpdate.ts
@@ -10,12 +10,12 @@ export function useUpdate() {
 
   const updateAction = async (formData: FormData) => {
     setUpdateState({ status: 'in_progress' });
-    try {
-      await handlePasswordChange(formData);
+    const status = await handlePasswordChange(formData);
+    if (status.status === 'success') {
       setUpdateState({ status: 'success' });
       toast.success('Password updated successfully');
       router.refresh();
-    } catch (error) {
+    } else {
       setUpdateState({ status: 'failed' });
       toast.error('Failed to update password');
     }


### PR DESCRIPTION
Add a try-catch block to `handlePasswordChange` in `app/(auth)/actions.ts` to ensure a valid status is returned.

* **app/(auth)/actions.ts**
  - Add a try-catch block to `handlePasswordChange`.
  - Modify `handlePasswordChange` to return a status.
  - Define `PasswordChangeStatus` interface.

* **app/(auth)/hooks/useReset.ts**
  - Update `resetAction` to use the status from `handlePasswordChange`.

* **app/(auth)/hooks/useUpdate.ts**
  - Update `updateAction` to use the status from `handlePasswordChange`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BarreraSlzr/session/pull/22?shareId=2fc364d1-eec7-4cdd-9492-873bf811f98d).