### PR TITLE
Add to readme how we generate uuid as credentials aka token for each auth method

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ The following functions use `createAuthMethod` to generate tokens:
 - `resetPassword` in `app/(auth)/lib/db/queries.ts` generates a reset password token.
 - `sendVerificationEmail` in `app/(auth)/lib/email.ts` generates a verification token.
 - `sendResetPasswordEmail` in `app/(auth)/lib/email.ts` generates a reset password token.
+- `createPasskey` in `app/(auth)/lib/db/queries.ts` generates a passkey token.
+- `createPassword` in `app/(auth)/lib/db/queries.ts` is the only method where a token is not generated. Instead, a hashed password is stored.
+
+### Explanation of expiresAt and verifiedAt
+
+For each authentication method, the `expiresAt` field indicates when the token will expire, and the `verifiedAt` field indicates when the token was verified.
+
 
 ## User Authentication Flows
 


### PR DESCRIPTION
Add explanation of UUID generation as credentials (tokens) in `README.md`.

* Add a section under "Core Functions and Usage" explaining the generation of UUIDs as credentials.
* Mention that UUIDs are generated in the `createAuthMethod` function in `app/(auth)/lib/db/queries.ts`.
* List the functions that use `createAuthMethod` to generate tokens: `createSession`, `resetPassword`, `sendVerificationEmail`, and `sendResetPasswordEmail`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BarreraSlzr/session/pull/24?shareId=b795fde5-599a-4b42-ad72-c6817a81e519).