### PR TITLE
Add passkey authentication using server action

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 import { z } from "zod";
-import { createSession } from "./lib/session";
-import { createUser, getUser, createPassword, validatePassword, updatePassword, resetPassword, verifyCredential, getAuthMethodForReset, getAuthMethodForValidation, getAuthMethodForUpdate } from "@/app/(auth)/lib/db/queries";
+import { createSession, getUserIdFromSession } from "./lib/session";
+import { createUser, getUser, createPassword, validatePassword, updatePassword, resetPassword, verifyCredential, getAuthMethodForReset, getAuthMethodForValidation, getAuthMethodForUpdate, getPasskeyChallenge, verifyAuthenticationResponse } from "@/app/(auth)/lib/db/queries";
 import { getCookie } from "@/app/(auth)/lib/cookies";
 import { handleAuthMethodValidation, errorMessages } from "@/app/(auth)/lib/token";
 
@@ -105,6 +105,28 @@ export const handlePasswordChange = async (formData: FormData): Promise<Password
     return { status: "success" };
   } catch (error) {
     console.error("Password change error:", error);
+    return { status: "failed" };
+  }
+};
+
+export interface Status {
+  status: "success" | "failed" | "invalid_data";
+}
+
+export const handlePasskeyAuth = async (formData: FormData): Promise<Status> => {
+  try {
+    const userId = await getUserIdFromSession();
+    const passkey = await getPasskeyChallenge(userId);
+    const verification = await verifyAuthenticationResponse({
+      ...formData
+    }, passkey);
+    if (verification.verified) {
+      await createSession(userId);
+      return { status: "success" };
+    }
+    return { status: "failed" };
+  } catch (error) {
+    console.error("Passkey authentication error:", error);
     return { status: "failed" };
   }
 };


### PR DESCRIPTION
Add passkey server action and update usePasskey hook to use it and display toast messages.

* **app/(auth)/actions.ts**
  - Add `handlePasskeyAuth` function to handle passkey authentication using `(formData: FormData): Promise<Status>`.
  - Export `handlePasskeyAuth` function.
  - Implement logic to get user ID from session, get passkey challenge, verify authentication response, and create session.

* **app/(auth)/hooks/usePasskey.ts**
  - Import `handlePasskeyAuth` function from `app/(auth)/actions.ts`.
  - Update `handlePasskeyRequest` to use `handlePasskeyAuth` function.
  - Display appropriate toast messages based on the authentication status (success, failed, invalid data).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BarreraSlzr/session/pull/26?shareId=84ccba08-2b10-479a-8d02-61e880fa1968).