### PR TITLE
Refactor passkey functions to use startAuthentication and startRegistration

### DIFF
--- a/app/(auth)/hooks/usePasskey.ts
+++ b/app/(auth)/hooks/usePasskey.ts
@@ -3,15 +3,27 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 import { handlePasskeyAuth, handlePasskeyRegistration } from '@/app/(auth)/actions'
+import { startAuthentication, startRegistration } from '@simplewebauthn/browser'
 
 export function usePasskey() {
   const router = useRouter()
   const [isLoading, setIsLoading] = useState(false)
 
-  const handlePasskeyRequest = async (isRegistration: boolean = false) => {
+  const handlePasskeyRequest = async (email: string, isRegistration: boolean = false) => {
     setIsLoading(true)
     try {
       const formData = new FormData()
+      formData.append('email', email)
+
+      let response
+      if (isRegistration) {
+        response = await startRegistration()
+      } else {
+        response = await startAuthentication()
+      }
+
+      formData.append('response', JSON.stringify(response))
+
       const status = isRegistration ? await handlePasskeyRegistration({ status: 'idle' }, formData) : await handlePasskeyAuth({ status: 'idle' }, formData)
 
       if (status.status === 'success') {

--- a/app/(auth)/lib/passkey.ts
+++ b/app/(auth)/lib/passkey.ts
@@ -2,6 +2,8 @@ import {
   GenerateRegistrationOptionsOpts,
   VerifyRegistrationResponseOpts,
   VerifyAuthenticationResponseOpts,
+  verifyRegistrationResponse as verifyRegistrationResponseServer,
+  verifyAuthenticationResponse as verifyAuthenticationResponseServer,
 } from '@simplewebauthn/server';
 import { AuthMethod } from '@/app/(auth)/lib/db/types';
 
@@ -34,7 +36,7 @@ export function verifyRegistrationResponse(response: any, challenge: string) {
   };
 
   // Call the actual verification function from @simplewebauthn/server
-  return verifyRegistrationResponse(opts);
+  return verifyRegistrationResponseServer(opts);
 }
 
 export function verifyAuthenticationResponse(response: any, authMethod: AuthMethod) {
@@ -46,5 +48,5 @@ export function verifyAuthenticationResponse(response: any, authMethod: AuthMeth
   };
 
   // Call the actual verification function from @simplewebauthn/server
-  return verifyAuthenticationResponse(opts);
+  return verifyAuthenticationResponseServer(opts);
 }


### PR DESCRIPTION
Refactor `usePasskey` hook and passkey functions to handle authentication and registration responses.

* **`app/(auth)/hooks/usePasskey.ts`**
  - Import `startAuthentication` and `startRegistration` from `@simplewebauthn/browser`.
  - Update `handlePasskeyRequest` to call `startAuthentication` or `startRegistration` based on `isRegistration` flag.
  - Handle the response from `startAuthentication` and `startRegistration` and pass it to the server-side verification functions.
  - Send response as formData to passkeyActions.

* **`app/(auth)/lib/passkey.ts`**
  - Import `verifyRegistrationResponse` and `verifyAuthenticationResponse` from `@simplewebauthn/server`.
  - Update `verifyRegistrationResponse` to call `verifyRegistrationResponseServer`.
  - Update `verifyAuthenticationResponse` to call `verifyAuthenticationResponseServer`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BarreraSlzr/session/pull/29?shareId=9222d6eb-8874-4455-a731-433845c3f0fa).