### PR TITLE
Refactor passkey auth method using Server Action for POST examples and API Routes for GET use cases

### DIFF
--- a/app/(auth)/api/passkey/generate-authenticate-options/route.ts
+++ b/app/(auth)/api/passkey/generate-authenticate-options/route.ts
@@ -1,0 +1,27 @@
+import { generateAuthenticationOptions } from "@simplewebauthn/server";
+import { getUserIdFromSession, getUser } from "@/app/(auth)/lib/session";
+
+export async function GET(req: Request) {
+  try {
+    const userId = await getUserIdFromSession();
+    const user = await getUser(userId);
+
+    const options = generateAuthenticationOptions({
+      rpID: "your-app-id",
+      userVerification: "preferred",
+      timeout: 60000,
+      allowCredentials: [
+        {
+          id: userId,
+          type: "public-key",
+          transports: ["usb", "ble", "nfc"],
+        },
+      ],
+    });
+
+    return new Response(JSON.stringify(options), { status: 200 });
+  } catch (error) {
+    console.error("Error generating authentication options:", error);
+    return new Response(JSON.stringify({ error: "Internal Server Error" }), { status: 500 });
+  }
+}

--- a/app/(auth)/api/passkey/generate-register-options/route.ts
+++ b/app/(auth)/api/passkey/generate-register-options/route.ts
@@ -1,0 +1,28 @@
+import { generateRegistrationOptions } from "@simplewebauthn/server";
+import { getUserIdFromSession, getUser } from "@/app/(auth)/lib/session";
+
+export async function GET(req: Request) {
+  try {
+    const userId = await getUserIdFromSession();
+    const user = await getUser(userId);
+
+    const options = generateRegistrationOptions({
+      rpName: "Your App Name",
+      rpID: "your-app-id",
+      userID: userId,
+      userName: user.email,
+      attestationType: "direct",
+      authenticatorSelection: {
+        authenticatorAttachment: "platform",
+        requireResidentKey: false,
+        userVerification: "preferred",
+      },
+      timeout: 60000,
+    });
+
+    return new Response(JSON.stringify(options), { status: 200 });
+  } catch (error) {
+    console.error("Error generating registration options:", error);
+    return new Response(JSON.stringify({ error: "Internal Server Error" }), { status: 500 });
+  }
+}

--- a/app/(auth)/api/passkey/verify-authentication/route.ts
+++ b/app/(auth)/api/passkey/verify-authentication/route.ts
@@ -1,0 +1,25 @@
+import { verifyAuthenticationResponse } from "@simplewebauthn/server";
+import { getUserIdFromSession, renewSession } from "@/app/(auth)/lib/session";
+import { getPasskeyChallenge } from "@/app/(auth)/lib/db/queries";
+
+export async function POST(req: Request) {
+  try {
+    const formData = await req.formData();
+    const response = JSON.parse(formData.get("response") as string);
+
+    const userId = await getUserIdFromSession();
+    const passkey = await getPasskeyChallenge(userId);
+
+    const verification = await verifyAuthenticationResponse(response, passkey);
+
+    if (verification.verified) {
+      await renewSession(userId);
+      return new Response(JSON.stringify({ status: "success" }), { status: 200 });
+    }
+
+    return new Response(JSON.stringify({ status: "failed" }), { status: 400 });
+  } catch (error) {
+    console.error("Error verifying authentication response:", error);
+    return new Response(JSON.stringify({ error: "Internal Server Error" }), { status: 500 });
+  }
+}

--- a/app/(auth)/api/passkey/verify-registration/route.ts
+++ b/app/(auth)/api/passkey/verify-registration/route.ts
@@ -1,0 +1,25 @@
+import { verifyRegistrationResponse } from "@simplewebauthn/server";
+import { getUserIdFromSession, renewSession } from "@/app/(auth)/lib/session";
+import { getUser } from "@/app/(auth)/lib/db/queries";
+
+export async function POST(req: Request) {
+  try {
+    const formData = await req.formData();
+    const response = JSON.parse(formData.get("response") as string);
+
+    const userId = await getUserIdFromSession();
+    const user = await getUser(userId);
+
+    const verification = await verifyRegistrationResponse(response, user.email);
+
+    if (verification.verified) {
+      await renewSession(userId);
+      return new Response(JSON.stringify({ passkey: verification.passkey }), { status: 200 });
+    }
+
+    return new Response(JSON.stringify({ status: "failed" }), { status: 400 });
+  } catch (error) {
+    console.error("Error verifying registration response:", error);
+    return new Response(JSON.stringify({ error: "Internal Server Error" }), { status: 500 });
+  }
+}


### PR DESCRIPTION
Add new API routes for passkey authentication and registration.

* **Generate Registration Options**: Add `app/(auth)/api/passkey/generate-register-options/route.ts` to generate registration options using `generateRegistrationOptions` from `@simplewebauthn/server`.
* **Generate Authentication Options**: Add `app/(auth)/api/passkey/generate-authenticate-options/route.ts` to generate authentication options using `generateAuthenticationOptions` from `@simplewebauthn/server`.
* **Verify Authentication**: Add `app/(auth)/api/passkey/verify-authentication/route.ts` to verify authentication response using `verifyAuthenticationResponse` from `@simplewebauthn/server` and renew session on successful verification.
* **Verify Registration**: Add `app/(auth)/api/passkey/verify-registration/route.ts` to verify registration response using `verifyRegistrationResponse` from `@simplewebauthn/server` and return `Passkey` on successful verification.

Update `usePasskey` hook to use new API routes.

* **Handle Passkey Request**: Update `handlePasskeyRequest` in `app/(auth)/hooks/usePasskey.ts` to use `fetch` for calling new GET and POST endpoints, and update error handling to reflect new API responses.

Remove unused functions from `actions.ts`.

* **Remove Functions**: Remove `handlePasskeyAuth` and `handlePasskeyRegistration` functions from `app/(auth)/actions.ts` and update imports to remove unused functions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BarreraSlzr/session/pull/30?shareId=bcbf9fd5-781c-40a1-94c0-9767cf733df9).