### PR TITLE
Add passkey authentication using getPasskeyChallenge

### DIFF
--- a/app/(auth)/api/passkey/generate-authenticate-options/route.ts
+++ b/app/(auth)/api/passkey/generate-authenticate-options/route.ts
@@ -1,10 +1,14 @@
 import { generateAuthenticationOptions } from "@simplewebauthn/server";
 import { getUserIdFromSession, getUser } from "@/app/(auth)/lib/session";
+import { createPasskey } from "@/app/(auth)/lib/db/queries";
 
 export async function GET(req: Request) {
   try {
     const userId = await getUserIdFromSession();
     const user = await getUser(userId);
+
+    // Create a passkey for the user
+    const passkey = await createPasskey(userId);
 
     const options = generateAuthenticationOptions({
       rpID: "your-app-id",
@@ -12,7 +16,7 @@ export async function GET(req: Request) {
       timeout: 60000,
       allowCredentials: [
         {
-          id: userId,
+          id: passkey.credential,
           type: "public-key",
           transports: ["usb", "ble", "nfc"],
         },


### PR DESCRIPTION
Add `createPasskey` function call and update `allowCredentials` in `generate-authenticate-options` endpoint.

* Import `createPasskey` from `queries.ts`.
* Add call to `createPasskey` before generating authentication options.
* Update `allowCredentials` to use the passkey created.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BarreraSlzr/session/pull/31?shareId=8a6c2d6a-7d4c-4da9-bdcc-2c263ea5f6b9).