### PR TITLE
Update passkey verification to use server actions

### DIFF
--- a/app/(auth)/hooks/usePasskey.ts
+++ b/app/(auth)/hooks/usePasskey.ts
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
 import { startAuthentication, startRegistration } from '@simplewebauthn/browser'
+import { verifyAuthentication, verifyRegistration } from '@/app/(auth)/actions'
 
 export function usePasskey() {
   const router = useRouter()
@@ -34,16 +35,12 @@ export function usePasskey() {
       const formData = new FormData();
       formData.append('response', JSON.stringify(webAuthnResponse));
 
-      const verifyResponse = await fetch(`/api/passkey/${isRegistration ? 'verify-registration' : 'verify-authentication'}`, {
-        method: 'POST',
-        body: formData,
-      });
-
-      if (!verifyResponse.ok) {
-        throw new Error('Failed to verify response');
+      let result;
+      if (isRegistration) {
+        result = await verifyRegistration(formData);
+      } else {
+        result = await verifyAuthentication(formData);
       }
-
-      const result = await verifyResponse.json();
 
       if (result.status === 'success') {
         toast.success(`WebAuthn ${isRegistration ? 'registration' : 'login'} successful`)


### PR DESCRIPTION
Move the POST call logic from the `usePasskey` hook to server actions in `app/(auth)/actions.ts`.

* **Add server actions in `app/(auth)/actions.ts`**:
  - Add `verifyAuthentication` server action to handle passkey authentication verification.
  - Add `verifyRegistration` server action to handle passkey registration verification.

* **Modify `usePasskey` hook in `app/(auth)/hooks/usePasskey.ts`**:
  - Import `verifyAuthentication` and `verifyRegistration` server actions.
  - Modify `handlePasskeyRequest` to call `verifyAuthentication` server action for authentication.
  - Modify `handlePasskeyRequest` to call `verifyRegistration` server action for registration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BarreraSlzr/session/pull/32?shareId=b7fb3fe0-5a3a-4939-afda-1c48b7fc3124).